### PR TITLE
cosmos.config examples should use module.exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ It's preferred to use CRA's own webpack config (instead of duplicating it).
 
 ```js
 // cosmos.config.js
-export default {
+module.exports = {
   componentPaths: ['src/components'],
   containerQuerySelector: '#root',
   webpackConfigPath: 'react-scripts/config/webpack.config.dev'
@@ -283,7 +283,7 @@ Next.js apps run on both client & server, so compilation is done via Babel plugi
 
 ```js
 // cosmos.config.js
-export default {
+module.exports = {
   componentPaths: ['components'],
 };
 ```


### PR DESCRIPTION
For compatibility with [create-react-app](https://github.com/facebookincubator/create-react-app).

Webpack 2 handles ES6 modules natively, so CRA's `react-app` Babel preset is designed to leave them intact. That means that the present doesn't have the `babel-plugin-transform-es2015-modules-commonjs` plugin necessary for `babel-register` to transform the `export default` in the current`cosmos.config.js` example for CRA. 